### PR TITLE
improve gnome edition

### DIFF
--- a/editions/gnome
+++ b/editions/gnome
@@ -12,6 +12,7 @@ man-pages
 man-db
 zswap-arm
 
+
 # Sound, video and bluetooth
 pavucontrol
 pulseaudio-alsa
@@ -28,6 +29,7 @@ libva-v4l2-request
 
 # Display Manager
 gdm
+xf86-video-fbdev
 
 # Network
 avahi

--- a/services/gnome
+++ b/services/gnome
@@ -3,3 +3,4 @@ NetworkManager.service
 bluetooth.service
 tlp.service
 zswap-arm.service
+gdm.service


### PR DESCRIPTION
The gnome profile needs fbdev & the gdm login manager to start by default